### PR TITLE
AC-417 Bugfix release

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -48,7 +48,7 @@ resource "aws_iam_policy_attachment" "exclusive_policy_attachment" {
 
   name       = "${lookup(var.roles[count.index], "policy_name")}"
   roles      = ["${element(aws_iam_role.roles.*.name, count.index)}"]
-  policy_arn = "${element(aws_iam_policy.policies.*.arn, count.index)}"
+  policy_arn = "${aws_iam_policy.policies.*.arn[count.index]}"
 }
 
 # Additive adding of roles
@@ -56,5 +56,5 @@ resource "aws_iam_role_policy_attachment" "imperative_policy_attachment" {
   count = "${var.exclusive_policy_attachment ? 0 : length(var.roles)}"
 
   role       = "${element(aws_iam_role.roles.*.name, count.index)}"
-  policy_arn = "${element(aws_iam_policy.policies.*.arn, count.index)}"
+  policy_arn = "${aws_iam_policy.policies.*.arn[count.index]}"
 }

--- a/main.tf
+++ b/main.tf
@@ -17,9 +17,9 @@ resource "aws_iam_role" "roles" {
   force_detach_policies = "${var.force_detach_policies}"
 
   tags = "${merge(
-		map("Name", lookup(var.roles[count.index], "name")),
-		var.tags
-	)}"
+    map("Name", lookup(var.roles[count.index], "name")),
+    var.tags
+  )}"
 }
 
 # ------------------------------------------------------------------------------------------------

--- a/outputs.tf
+++ b/outputs.tf
@@ -104,11 +104,6 @@ output "imperative_policy_attachment_ids" {
   value       = ["${aws_iam_role_policy_attachment.imperative_policy_attachment.*.id}"]
 }
 
-output "imperative_policy_attachment_names" {
-  description = "A list of names of shared policy attachments."
-  value       = ["${aws_iam_role_policy_attachment.imperative_policy_attachment.*.name}"]
-}
-
 output "imperative_policy_attachment_policy_arns" {
   description = "A list of ARNs of shared policy attachments."
   value       = ["${aws_iam_role_policy_attachment.imperative_policy_attachment.*.policy_arn}"]


### PR DESCRIPTION
# Bugfix release

* Fix imperative policy attachment by removing wrong output
* Fix "resource re-created" when appending roles (thanks to @maartenvanderhoef for [providing the fix](https://gist.github.com/maartenvanderhoef/596fca33c4cb93c76b6cb041be4745d4))

## Tagging

After merge tag with `v0.1.1`