### PR TITLE
Release 0.2.0

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -6,8 +6,8 @@ resource "aws_iam_role" "roles" {
   count = "${length(var.roles)}"
 
   name        = "${lookup(var.roles[count.index], "name")}"
-  path        = "${lookup(var.roles[count.index], "path", var.role_path)}"
-  description = "${lookup(var.roles[count.index], "desc", var.role_desc)}"
+  path        = "${lookup(var.roles[count.index], "path", "") == "" ? var.role_path : lookup(var.roles[count.index], "path")}"
+  description = "${lookup(var.roles[count.index], "desc", "") == "" ? var.role_desc : lookup(var.roles[count.index], "desc")}"
 
   # This policy defines who/what is allowed to use the current role
   assume_role_policy = "${file(lookup(var.roles[count.index], "trust_policy_file"))}"
@@ -30,8 +30,8 @@ resource "aws_iam_policy" "policies" {
   count = "${length(var.roles)}"
 
   name        = "${lookup(var.roles[count.index], "policy_name")}"
-  path        = "${lookup(var.roles[count.index], "policy_path", var.policy_path)}"
-  description = "${lookup(var.roles[count.index], "policy_desc", var.policy_desc)}"
+  path        = "${lookup(var.roles[count.index], "policy_path", "") == "" ? var.policy_path : lookup(var.roles[count.index], "policy_path")}"
+  description = "${lookup(var.roles[count.index], "policy_desc", "") == "" ? var.policy_desc : lookup(var.roles[count.index], "policy_desc")}"
 
   # This defines what permissions our role will be given
   policy = "${file(lookup(var.roles[count.index], "policy_file"))}"

--- a/main.tf
+++ b/main.tf
@@ -2,8 +2,16 @@
 # Create Roles
 # ------------------------------------------------------------------------------------------------
 
+# Lazy evaluation of count to overcome:
+# module.aws_iam_permissions.aws_iam_role.roles: aws_iam_role.roles: value of 'count' cannot be computed
+resource "null_resource" "count" {
+  triggers {
+    count = "${length(var.roles)}"
+  }
+}
+
 resource "aws_iam_role" "roles" {
-  count = "${length(var.roles)}"
+  count = "${null_resource.count.triggers.count}"
 
   name        = "${lookup(var.roles[count.index], "name")}"
   path        = "${lookup(var.roles[count.index], "path", "") == "" ? var.role_path : lookup(var.roles[count.index], "path")}"
@@ -24,6 +32,8 @@ resource "aws_iam_role" "roles" {
     map("Name", lookup(var.roles[count.index], "name")),
     var.tags
   )}"
+
+  depends_on = ["null_resource.count"]
 }
 
 # ------------------------------------------------------------------------------------------------
@@ -31,7 +41,7 @@ resource "aws_iam_role" "roles" {
 # ------------------------------------------------------------------------------------------------
 
 resource "aws_iam_policy" "policies" {
-  count = "${length(var.roles)}"
+  count = "${null_resource.count.triggers.count}"
 
   name        = "${lookup(var.roles[count.index], "policy_name")}"
   path        = "${lookup(var.roles[count.index], "policy_path", "") == "" ? var.policy_path : lookup(var.roles[count.index], "policy_path")}"
@@ -48,7 +58,7 @@ resource "aws_iam_policy" "policies" {
 
 # Exclusive attachment of roles
 resource "aws_iam_policy_attachment" "exclusive_policy_attachment" {
-  count = "${var.exclusive_policy_attachment ? length(var.roles) : 0}"
+  count = "${var.exclusive_policy_attachment ? null_resource.count.triggers.count : 0}"
 
   name       = "${lookup(var.roles[count.index], "policy_name")}"
   roles      = ["${element(aws_iam_role.roles.*.name, count.index)}"]
@@ -57,7 +67,7 @@ resource "aws_iam_policy_attachment" "exclusive_policy_attachment" {
 
 # Additive adding of roles
 resource "aws_iam_role_policy_attachment" "imperative_policy_attachment" {
-  count = "${var.exclusive_policy_attachment ? 0 : length(var.roles)}"
+  count = "${var.exclusive_policy_attachment ? 0 : null_resource.count.triggers.count}"
 
   role       = "${element(aws_iam_role.roles.*.name, count.index)}"
   policy_arn = "${aws_iam_policy.policies.*.arn[count.index]}"

--- a/main.tf
+++ b/main.tf
@@ -12,6 +12,10 @@ resource "aws_iam_role" "roles" {
   # This policy defines who/what is allowed to use the current role
   assume_role_policy = "${file(lookup(var.roles[count.index], "trust_policy_file"))}"
 
+  # The boundary defines the maximum allowed permissions which cannot exceed.
+  # Even if the policy has higher permission, the boundary sets the final limit
+  permissions_boundary = "${lookup(var.roles[count.index], "permissions_boundary", "")}"
+
   # Allow session for X seconds
   max_session_duration  = "${var.max_session_duration}"
   force_detach_policies = "${var.force_detach_policies}"

--- a/variables.tf
+++ b/variables.tf
@@ -14,6 +14,7 @@
 #		policy_path = "/"                  # defaults to 'policy_path' if not set
 #		policy_desc = "description"        # defaults to 'policy_desc' if not set
 #		policy_file = "policy.json"        # required: defines the policy
+#		permissions_boundary = "arn:..."   # optional: ARN of policy to set as permission boundary
 #	}
 #]
 


### PR DESCRIPTION
# Release 0.2.0

This PR adds the following features:

* Ensure default values are also assigned if they are empty instead of just unset
* Add feature: permissions_boundary
* Fix 'count' cannot be computed by lazy loading it in a null_resource

## Tagging

Next tag will be `v0.2.0`