### PR TITLE
Add role_count to overcome: count cannot be computed

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,6 +29,8 @@ module "iam_roles" {
       policy_file = "logins/admin-policy.json"
     }
   ]
+  # Required to overcome some limitations of Terraform 0.11.x
+  role_count = 1
 ```
 
 **`logins/admin-assume.json`**

--- a/variables.tf
+++ b/variables.tf
@@ -23,6 +23,10 @@ variable "roles" {
   type        = "list"
 }
 
+variable "role_count" {
+  description = "An integer that specifies the number of items in 'roles' to overcome limitations of Terraform 0.11.x."
+}
+
 # -------------------------------------------------------------------------------------------------
 # Default Role settings
 # -------------------------------------------------------------------------------------------------


### PR DESCRIPTION
## Description

Unfortunately I found a new case in which the "count cannot be computed" error occurred, which I was unable to solve with `null_resources`. Therefore I am introducing the `role_count` variable, which specifies the size of the roles.