### PR TITLE
Terraform 0.12 version

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,36 +1,83 @@
+ifneq (,)
+.error This Makefile requires GNU Make.
+endif
+
+.PHONY: help gen lint test _gen-main _gen-examples _gen-modules _lint-files _lint-fmt _lint-json _pull-tf _pull-tfdocs _pull-fl _pull-jl
+
 CURRENT_DIR = $(dir $(abspath $(lastword $(MAKEFILE_LIST))))
 TF_EXAMPLES = $(sort $(dir $(wildcard $(CURRENT_DIR)examples/*/)))
+TF_MODULES  = $(sort $(dir $(wildcard $(CURRENT_DIR)modules/*/)))
 
-.PHONY: test
+# -------------------------------------------------------------------------------------------------
+# Container versions
+# -------------------------------------------------------------------------------------------------
+TF_VERSION      = light
+TFDOCS_VERSION  = 0.6.0
+FL_VERSION      = 0.2
+JL_VERSION      = latest-0.4
 
+
+# -------------------------------------------------------------------------------------------------
+# Enable linter (file-lint, terraform fmt, jsonlint)
+# -------------------------------------------------------------------------------------------------
+LINT_FL_ENABLE = 1
+LINT_TF_ENABLE = 1
+LINT_JL_ENABLE = 1
+
+
+# -------------------------------------------------------------------------------------------------
+# terraform-docs defines
+# -------------------------------------------------------------------------------------------------
+# Adjust your delimiter here or overwrite via make arguments
+DELIM_START = <!-- BEGINNING OF PRE-COMMIT-TERRAFORM DOCS HOOK -->
+DELIM_CLOSE = <!-- END OF PRE-COMMIT-TERRAFORM DOCS HOOK -->
+# What arguments to append to terraform-docs command
+TFDOCS_ARGS = --sort-inputs-by-required --with-aggregate-type-defaults
+
+
+# -------------------------------------------------------------------------------------------------
+# Default target
+# -------------------------------------------------------------------------------------------------
 help:
+	@echo "gen        Generate terraform-docs output and replace in README.md's"
 	@echo "lint       Static source code analysis"
 	@echo "test       Integration tests"
 
 
+# -------------------------------------------------------------------------------------------------
+# Standard targets
+# -------------------------------------------------------------------------------------------------
+gen: _pull-tfdocs
+	@echo "################################################################################"
+	@echo "# Terraform-docs generate"
+	@echo "################################################################################"
+	@$(MAKE) --no-print-directory _gen-main
+	@$(MAKE) --no-print-directory _gen-examples
+	@$(MAKE) --no-print-directory _gen-modules
+
 lint:
-	@# Lint all Terraform files
-	@echo "################################################################################"
-	@echo "# Terraform fmt"
-	@echo "################################################################################"
-	@if docker run -it --rm -v "$(CURRENT_DIR):/t:ro" --workdir "/t" hashicorp/terraform:light \
-		fmt -check=true -diff=true -write=false -list=true .; then \
-		echo "OK"; \
-	else \
-		echo "Failed"; \
-		exit 1; \
-	fi;
-	@echo
+	@if [ "$(LINT_FL_ENABLE)" = "1" ]; then \
+		$(MAKE) --no-print-directory _lint-files; \
+	fi
+	@if [ "$(LINT_TF_ENABLE)" = "1" ]; then \
+		$(MAKE) --no-print-directory _lint-fmt; \
+	fi
+	@if [ "$(LINT_JL_ENABLE)" = "1" ]; then \
+		$(MAKE) --no-print-directory _lint-json; \
+	fi
 
-
-test:
+test: _pull-tf
 	@$(foreach example,\
 		$(TF_EXAMPLES),\
 		DOCKER_PATH="/t/examples/$(notdir $(patsubst %/,%,$(example)))"; \
 		echo "################################################################################"; \
-		echo "# Terraform init:  $${DOCKER_PATH}"; \
+		echo "# examples/$$( basename $${DOCKER_PATH} )"; \
 		echo "################################################################################"; \
-		if docker run -it --rm -v "$(CURRENT_DIR):/t" --workdir "$${DOCKER_PATH}" hashicorp/terraform:light \
+		echo; \
+		echo "------------------------------------------------------------"; \
+		echo "# Terraform init"; \
+		echo "------------------------------------------------------------"; \
+		if docker run -it --rm -v "$(CURRENT_DIR):/t" --workdir "$${DOCKER_PATH}" hashicorp/terraform:$(TF_VERSION) \
 			init \
 				-verify-plugins=true \
 				-lock=false \
@@ -43,27 +90,147 @@ test:
 			echo "OK"; \
 		else \
 			echo "Failed"; \
-			docker run -it --rm -v "$(CURRENT_DIR):/t" --workdir "$${DOCKER_PATH}" --entrypoint=rm hashicorp/terraform:light -rf .terraform/ || true; \
+			docker run -it --rm -v "$(CURRENT_DIR):/t" --workdir "$${DOCKER_PATH}" --entrypoint=rm hashicorp/terraform:$(TF_VERSION) -rf .terraform/ || true; \
 			exit 1; \
 		fi; \
 		echo; \
-	)
-	@$(foreach example,\
-		$(TF_EXAMPLES),\
-		DOCKER_PATH="/t/examples/$(notdir $(patsubst %/,%,$(example)))"; \
-		echo "################################################################################"; \
-		echo "# Terraform validate:  $${DOCKER_PATH}"; \
-		echo "################################################################################"; \
-		if docker run -it --rm -v "$(CURRENT_DIR):/t" --workdir "$${DOCKER_PATH}" hashicorp/terraform:light \
+		echo "------------------------------------------------------------"; \
+		echo "# Terraform validate"; \
+		echo "------------------------------------------------------------"; \
+		if docker run -it --rm -v "$(CURRENT_DIR):/t" --workdir "$${DOCKER_PATH}" hashicorp/terraform:$(TF_VERSION) \
 			validate \
 				-check-variables=true $(ARGS) \
 				.; then \
 			echo "OK"; \
-			docker run -it --rm -v "$(CURRENT_DIR):/t" --workdir "$${DOCKER_PATH}" --entrypoint=rm hashicorp/terraform:light -rf .terraform/ || true; \
+			docker run -it --rm -v "$(CURRENT_DIR):/t" --workdir "$${DOCKER_PATH}" --entrypoint=rm hashicorp/terraform:$(TF_VERSION) -rf .terraform/ || true; \
 		else \
 			echo "Failed"; \
-			docker run -it --rm -v "$(CURRENT_DIR):/t" --workdir "$${DOCKER_PATH}" --entrypoint=rm hashicorp/terraform:light -rf .terraform/ || true; \
+			docker run -it --rm -v "$(CURRENT_DIR):/t" --workdir "$${DOCKER_PATH}" --entrypoint=rm hashicorp/terraform:$(TF_VERSION) -rf .terraform/ || true; \
 			exit 1; \
 		fi; \
 		echo; \
 	)
+
+
+# -------------------------------------------------------------------------------------------------
+# Helper Targets
+# -------------------------------------------------------------------------------------------------
+_gen-main:
+	@echo "------------------------------------------------------------"
+	@echo "# Main module"
+	@echo "------------------------------------------------------------"
+	@if docker run --rm \
+		-v $(CURRENT_DIR):/data \
+		-e DELIM_START='$(DELIM_START)' \
+		-e DELIM_CLOSE='$(DELIM_CLOSE)' \
+		cytopia/terraform-docs:$(TFDOCS_VERSION) \
+		terraform-docs-replace-012 $(TFDOCS_ARGS) md README.md; then \
+		echo "OK"; \
+	else \
+		echo "Failed"; \
+		exit 1; \
+	fi
+
+_gen-examples:
+	@$(foreach example,\
+		$(TF_EXAMPLES),\
+		DOCKER_PATH="examples/$(notdir $(patsubst %/,%,$(example)))"; \
+		echo "------------------------------------------------------------"; \
+		echo "# $${DOCKER_PATH}"; \
+		echo "------------------------------------------------------------"; \
+		if docker run --rm \
+			-v $(CURRENT_DIR):/data \
+			-e DELIM_START='$(DELIM_START)' \
+			-e DELIM_CLOSE='$(DELIM_CLOSE)' \
+			cytopia/terraform-docs:$(TFDOCS_VERSION) \
+			terraform-docs-replace-012 $(TFDOCS_ARGS) md $${DOCKER_PATH}/README.md; then \
+			echo "OK"; \
+		else \
+			echo "Failed"; \
+			exit 1; \
+		fi; \
+	)
+
+_gen-modules:
+	@$(foreach module,\
+		$(TF_MODULES),\
+		DOCKER_PATH="modules/$(notdir $(patsubst %/,%,$(module)))"; \
+		echo "------------------------------------------------------------"; \
+		echo "# $${DOCKER_PATH}"; \
+		echo "------------------------------------------------------------"; \
+		if docker run --rm \
+			-v $(CURRENT_DIR):/data \
+			-e DELIM_START='$(DELIM_START)' \
+			-e DELIM_CLOSE='$(DELIM_CLOSE)' \
+			cytopia/terraform-docs:$(TFDOCS_VERSION) \
+			terraform-docs-replace-012 $(TFDOCS_ARGS) md $${DOCKER_PATH}/README.md; then \
+			echo "OK"; \
+		else \
+			echo "Failed"; \
+			exit 1; \
+		fi; \
+	)
+
+_lint-files: _pull-fl
+	@# Basic file linting
+	@echo "################################################################################"
+	@echo "# File-lint"
+	@echo "################################################################################"
+	@docker run --rm -v $(CURRENT_DIR):/data cytopia/file-lint:$(FL_VERSION) file-cr --text --ignore '.git/,.github/,.terraform/' --path .
+	@docker run --rm -v $(CURRENT_DIR):/data cytopia/file-lint:$(FL_VERSION) file-crlf --text --ignore '.git/,.github/,.terraform/' --path .
+	@docker run --rm -v $(CURRENT_DIR):/data cytopia/file-lint:$(FL_VERSION) file-trailing-single-newline --text --ignore '.git/,.github/,.terraform/' --path .
+	@docker run --rm -v $(CURRENT_DIR):/data cytopia/file-lint:$(FL_VERSION) file-trailing-space --text --ignore '.git/,.github/,.terraform/' --path .
+	@docker run --rm -v $(CURRENT_DIR):/data cytopia/file-lint:$(FL_VERSION) file-utf8 --text --ignore '.git/,.github/,.terraform/' --path .
+	@docker run --rm -v $(CURRENT_DIR):/data cytopia/file-lint:$(FL_VERSION) file-utf8-bom --text --ignore '.git/,.github/,.terraform/' --path .
+
+_lint-fmt: _pull-tf
+	@# Lint all Terraform files
+	@echo "################################################################################"
+	@echo "# Terraform fmt"
+	@echo "################################################################################"
+	@echo
+	@echo "------------------------------------------------------------"
+	@echo "# *.tf files"
+	@echo "------------------------------------------------------------"
+	@if docker run -it --rm -v "$(CURRENT_DIR):/t:ro" --workdir "/t" hashicorp/terraform:$(TF_VERSION) \
+		fmt -check=true -diff=true -write=false -list=true .; then \
+		echo "OK"; \
+	else \
+		echo "Failed"; \
+		exit 1; \
+	fi;
+	@echo
+	@echo "------------------------------------------------------------"
+	@echo "# *.tfvars files"
+	@echo "------------------------------------------------------------"
+	@if docker run --rm --entrypoint=/bin/sh -v "$(CURRENT_DIR):/t:ro" --workdir "/t" hashicorp/terraform:$(TF_VERSION) \
+		-c "find . -name '*.tfvars' -type f -print0 | xargs -0 -n1 terraform fmt -check=true -write=false -diff=true -list=true"; then \
+		echo "OK"; \
+	else \
+		echo "Failed"; \
+		exit 1; \
+	fi;
+	@echo
+
+_lint-json: _pull-jl
+	@# Lint all JSON files
+	@echo "################################################################################"
+	@echo "# Jsonlint"
+	@echo "################################################################################"
+	@if docker run --rm -v "$(CURRENT_DIR):/data:ro" cytopia/jsonlint:$(JL_VERSION) \
+		-t '  ' -i '*.terraform/*' '*.json'; then \
+		echo "OK"; \
+	else \
+		echo "Failed"; \
+		exit 1; \
+	fi;
+	@echo
+
+_pull-tf:
+	docker pull hashicorp/terraform:$(TF_VERSION)
+
+_pull-tfdocs:
+	docker pull cytopia/terraform-docs:$(TFDOCS_VERSION)
+
+_pull-fl:
+	docker pull cytopia/file-lint:$(FL_VERSION)

--- a/locals.tf
+++ b/locals.tf
@@ -7,16 +7,22 @@ locals {
   #
   # policies = [
   #   {
-  #     name = ""
-  #     path = ""
-  #     desc = ""
-  #     file = ""
+  #     name = "<policy-name>"
+  #     path = "<policy-path>"
+  #     desc = "<policy-desc>"
+  #     file = "<policy-file>"
+  #     vars = {
+  #       key = "val",
+  #     }
   #   },
   #   {
-  #     name = ""
-  #     path = ""
-  #     desc = ""
-  #     file = ""
+  #     name = "<policy-name>"
+  #     path = "<policy-path>"
+  #     desc = "<policy-desc>"
+  #     file = "<policy-file>"
+  #     vars = {
+  #       key = "val",
+  #     }
   #   },
   # }
   #
@@ -24,16 +30,22 @@ locals {
   #
   # policies = {
   #   "<policy-name>" = {
-  #     name = ""
-  #     path = ""
-  #     desc = ""
-  #     file = ""
+  #     name = "<policy-name>"
+  #     path = "<policy-path>"
+  #     desc = "<policy-desc>"
+  #     file = "<policy-file>"
+  #     vars = {
+  #       key = "val",
+  #     }
   #   }
   #   "<policy-name>" = {
-  #     name = ""
-  #     path = ""
-  #     desc = ""
-  #     file = ""
+  #     name = "<policy-name>"
+  #     path = "<policy-path>"
+  #     desc = "<policy-desc>"
+  #     file = "<policy-file>"
+  #     vars = {
+  #       key = "val",
+  #     }
   #   }
   # }
   policies = { for i, v in var.policies : var.policies[i]["name"] => v }
@@ -51,11 +63,13 @@ locals {
   # role_policies = [
   #   {
   #     "<role-name>:<policy-name>" = {
-  #       "name" = "<policy-name>"
-  #       "path" = "<policy-path>"
-  #       "desc" = "<policy-desc>"
-  #       "file" = "<policy-file>"
-  #       "vars" = {key = val}
+  #       name = "<policy-name>"
+  #       path = "<policy-path>"
+  #       desc = "<policy-desc>"
+  #       file = "<policy-file>"
+  #       vars = {
+  #         key = "val",
+  #       }
   #     }
   #   },
   # ]
@@ -84,16 +98,20 @@ locals {
   # inline_policies = [
   #   {
   #     "<role-name>:<policy-name>" = {
-  #       "name" = ""
-  #       "file" = ""
-  #       "vars" = {key = val}
+  #       name = "<policy-name>"
+  #       file = "<policy-file>"
+  #       vars = {
+  #         key = "val",
+  #       }
   #     }
   #   },
   #   {
   #     "<role-name>:<policy-name>" = {
-  #       "name" = ""
-  #       "file" = ""
-  #       "vars" = ""
+  #       name = "<policy-name>"
+  #       file = "<policy-file>"
+  #       vars = {
+  #         key = "val",
+  #       }
   #     }
   #   },
   # ]
@@ -121,10 +139,10 @@ locals {
   #
   # policy_arns = [
   #   {
-  #     "<role-name>:<policy-arn>" = "<policy-arn">
+  #     "<role-name>:<policy-arn>" = "<policy-arn>"
   #   },
   #   {
-  #     "<role-name>:<policy-arn>" = "<policy-arn">
+  #     "<role-name>:<policy-arn>" = "<policy-arn>"
   #   },
   # ]
   pa = flatten([

--- a/locals.tf
+++ b/locals.tf
@@ -1,0 +1,144 @@
+# -------------------------------------------------------------------------------------------------
+# Policy transformations
+# -------------------------------------------------------------------------------------------------
+
+locals {
+  # Transforn from:
+  #
+  # policies = [
+  #   {
+  #     name = ""
+  #     path = ""
+  #     desc = ""
+  #     file = ""
+  #   },
+  #   {
+  #     name = ""
+  #     path = ""
+  #     desc = ""
+  #     file = ""
+  #   },
+  # }
+  #
+  # Into the following format:
+  #
+  # policies = {
+  #   "<policy-name>" = {
+  #     name = ""
+  #     path = ""
+  #     desc = ""
+  #     file = ""
+  #   }
+  #   "<policy-name>" = {
+  #     name = ""
+  #     path = ""
+  #     desc = ""
+  #     file = ""
+  #   }
+  # }
+  policies = { for i, v in var.policies : var.policies[i]["name"] => v }
+}
+
+
+# -------------------------------------------------------------------------------------------------
+# Role Policy transformations
+# -------------------------------------------------------------------------------------------------
+
+locals {
+
+  # This local combines var.roles and var.policies and creates its own list as shown below:
+  #
+  # role_policies = [
+  #   {
+  #     "<role-name>:<policy-name>" = {
+  #        "name" = "<policy-name>"
+  #        "path" = "<policy-path>"
+  #        "desc" = "<policy-desc>"
+  #        "file" = "<policy-file>"
+  #     }
+  #   },
+  # ]
+
+  _role_policies = flatten([
+    for i, role in var.roles : [
+      for j, policy in lookup(var.roles[i], "policies", {}) : {
+        "${var.roles[i]["name"]}:${var.roles[i]["policies"][j]}" = local.policies[var.roles[i]["policies"][j]]
+      }
+    ]
+  ])
+  # The fix to bring it into the format stated at the top of this file
+  role_policies = {
+    for i, v in local._role_policies :
+    keys(local._role_policies[i])[0] => local._role_policies[i][keys(local._role_policies[i])[0]]
+  }
+}
+
+
+# -------------------------------------------------------------------------------------------------
+# Inline Policy transformations
+# -------------------------------------------------------------------------------------------------
+
+locals {
+  # This local extracts inline_policies from var.roles and combines the found policies
+  # with the role names as shown below:
+  #
+  #   inline_policies = [
+  #     {
+  #       "<role-name>:<policy-name>" = {
+  #         "name" = ""
+  #         "file" = ""
+  #       }
+  #     },
+  #     {
+  #       "<role-name>:<policy-name>" = {
+  #         "name" = ""
+  #         "file" = ""
+  #       }
+  #     },
+  #   ]
+
+  _inline_policies = flatten([
+    for i, role in var.roles : [
+      for j, inline_policy in lookup(var.roles[i], "inline_policies", {}) : {
+        "${var.roles[i]["name"]}:${var.roles[i]["inline_policies"][j]["name"]}" = inline_policy
+      }
+    ]
+  ])
+  # The fix to bring it into the format stated at the top of this file
+  inline_policies = {
+    for i, v in local._inline_policies :
+    keys(local._inline_policies[i])[0] => local._inline_policies[i][keys(local._inline_policies[i])[0]]
+  }
+}
+
+
+# -------------------------------------------------------------------------------------------------
+# Policy Arn transformations
+# -------------------------------------------------------------------------------------------------
+
+locals {
+  # This local extracts policy_arns from var.roles and combines the found policies
+  # with the role names as shown below:
+  #
+  #   policy_arns = [
+  #     {
+  #       "<role-name>:<policy-arn>" = "<policy-arn">
+  #     },
+  #     {
+  #       "<role-name>:<policy-arn>" = "<policy-arn">
+  #     },
+  #   ]
+
+  _policy_arns = flatten([
+    for i, role in var.roles : [
+      for j, policy_arn in lookup(var.roles[i], "policy_arns", {}) : {
+        "${var.roles[i]["name"]}:${var.roles[i]["policy_arns"][j]}" = policy_arn
+      }
+    ]
+  ])
+  # The fix to bring it into the format stated at the top of this file
+  policy_arns = {
+    for i, v in local._policy_arns :
+    keys(local._policy_arns[i])[0] => local._policy_arns[i][keys(local._policy_arns[i])[0]]
+  }
+}

--- a/locals.tf
+++ b/locals.tf
@@ -51,26 +51,25 @@ locals {
   # role_policies = [
   #   {
   #     "<role-name>:<policy-name>" = {
-  #        "name" = "<policy-name>"
-  #        "path" = "<policy-path>"
-  #        "desc" = "<policy-desc>"
-  #        "file" = "<policy-file>"
+  #       "name" = "<policy-name>"
+  #       "path" = "<policy-path>"
+  #       "desc" = "<policy-desc>"
+  #       "file" = "<policy-file>"
+  #       "vars" = {key = val}
   #     }
   #   },
   # ]
-
-  _role_policies = flatten([
-    for i, role in var.roles : [
-      for j, policy in lookup(var.roles[i], "policies", {}) : {
-        "${var.roles[i]["name"]}:${var.roles[i]["policies"][j]}" = local.policies[var.roles[i]["policies"][j]]
+  rp = flatten([
+    for role in var.roles : [
+      for policy in role["policies"] : {
+        role_name   = role.name
+        policy_name = policy
+        policy      = local.policies[policy]
       }
     ]
   ])
-  # The fix to bring it into the format stated at the top of this file
-  role_policies = {
-    for i, v in local._role_policies :
-    keys(local._role_policies[i])[0] => local._role_policies[i][keys(local._role_policies[i])[0]]
-  }
+
+  role_policies = { for obj in local.rp : "${obj.role_name}:${obj.policy_name}" => obj.policy }
 }
 
 
@@ -82,33 +81,33 @@ locals {
   # This local extracts inline_policies from var.roles and combines the found policies
   # with the role names as shown below:
   #
-  #   inline_policies = [
-  #     {
-  #       "<role-name>:<policy-name>" = {
-  #         "name" = ""
-  #         "file" = ""
-  #       }
-  #     },
-  #     {
-  #       "<role-name>:<policy-name>" = {
-  #         "name" = ""
-  #         "file" = ""
-  #       }
-  #     },
-  #   ]
-
-  _inline_policies = flatten([
-    for i, role in var.roles : [
-      for j, inline_policy in lookup(var.roles[i], "inline_policies", {}) : {
-        "${var.roles[i]["name"]}:${var.roles[i]["inline_policies"][j]["name"]}" = inline_policy
+  # inline_policies = [
+  #   {
+  #     "<role-name>:<policy-name>" = {
+  #       "name" = ""
+  #       "file" = ""
+  #       "vars" = {key = val}
+  #     }
+  #   },
+  #   {
+  #     "<role-name>:<policy-name>" = {
+  #       "name" = ""
+  #       "file" = ""
+  #       "vars" = ""
+  #     }
+  #   },
+  # ]
+  ip = flatten([
+    for role in var.roles : [
+      for inline_policy in role["inline_policies"] : {
+        role_name   = role.name
+        policy_name = inline_policy["name"]
+        policy      = inline_policy
       }
     ]
   ])
-  # The fix to bring it into the format stated at the top of this file
-  inline_policies = {
-    for i, v in local._inline_policies :
-    keys(local._inline_policies[i])[0] => local._inline_policies[i][keys(local._inline_policies[i])[0]]
-  }
+
+  inline_policies = { for obj in local.ip : "${obj.role_name}:${obj.policy_name}" => obj.policy }
 }
 
 
@@ -120,25 +119,23 @@ locals {
   # This local extracts policy_arns from var.roles and combines the found policies
   # with the role names as shown below:
   #
-  #   policy_arns = [
-  #     {
-  #       "<role-name>:<policy-arn>" = "<policy-arn">
-  #     },
-  #     {
-  #       "<role-name>:<policy-arn>" = "<policy-arn">
-  #     },
-  #   ]
-
-  _policy_arns = flatten([
-    for i, role in var.roles : [
-      for j, policy_arn in lookup(var.roles[i], "policy_arns", {}) : {
-        "${var.roles[i]["name"]}:${var.roles[i]["policy_arns"][j]}" = policy_arn
+  # policy_arns = [
+  #   {
+  #     "<role-name>:<policy-arn>" = "<policy-arn">
+  #   },
+  #   {
+  #     "<role-name>:<policy-arn>" = "<policy-arn">
+  #   },
+  # ]
+  pa = flatten([
+    for role in var.roles : [
+      for policy_arn in role["policy_arns"] : {
+        role_name  = role.name
+        policy_arn = policy_arn
+        policy     = policy_arn
       }
     ]
   ])
-  # The fix to bring it into the format stated at the top of this file
-  policy_arns = {
-    for i, v in local._policy_arns :
-    keys(local._policy_arns[i])[0] => local._policy_arns[i][keys(local._policy_arns[i])[0]]
-  }
+
+  policy_arns = { for obj in local.pa : "${obj.role_name}:${obj.policy_arn}" => obj.policy }
 }

--- a/main.tf
+++ b/main.tf
@@ -1,64 +1,100 @@
-# ------------------------------------------------------------------------------------------------
+# -------------------------------------------------------------------------------------------------
+# Set module requirements
+# -------------------------------------------------------------------------------------------------
+
+terraform {
+  # >= v0.12.6
+  required_version = ">= 0.12.6"
+}
+
+
+# -------------------------------------------------------------------------------------------------
+# Create defined Policies
+# -------------------------------------------------------------------------------------------------
+
+# Create customer managed policies
+resource "aws_iam_policy" "policies" {
+  for_each = local.policies
+
+  name        = lookup(each.value, "name")
+  path        = lookup(each.value, "path", "") == "" ? var.policy_path : lookup(each.value, "path")
+  description = lookup(each.value, "desc", "") == "" ? var.policy_desc : lookup(each.value, "desc")
+  policy      = templatefile(lookup(each.value, "file"), lookup(each.value, "vars"))
+}
+
+
+# -------------------------------------------------------------------------------------------------
 # Create Roles
-# ------------------------------------------------------------------------------------------------
+# -------------------------------------------------------------------------------------------------
 
+# Create roles
 resource "aws_iam_role" "roles" {
-  count = "${var.role_count}"
+  for_each = { for role in var.roles : role.name => role }
 
-  name        = "${lookup(var.roles[count.index], "name")}"
-  path        = "${lookup(var.roles[count.index], "path", "") == "" ? var.role_path : lookup(var.roles[count.index], "path")}"
-  description = "${lookup(var.roles[count.index], "desc", "") == "" ? var.role_desc : lookup(var.roles[count.index], "desc")}"
+  name        = lookup(each.value, "name")
+  path        = lookup(each.value, "path", "") == "" ? var.role_path : lookup(each.value, "path")
+  description = lookup(each.value, "desc", "") == "" ? var.role_desc : lookup(each.value, "desc")
 
   # This policy defines who/what is allowed to use the current role
-  assume_role_policy = "${file(lookup(var.roles[count.index], "trust_policy_file"))}"
+  assume_role_policy = file(lookup(each.value, "trust_policy_file"))
 
   # The boundary defines the maximum allowed permissions which cannot exceed.
   # Even if the policy has higher permission, the boundary sets the final limit
-  permissions_boundary = "${lookup(var.roles[count.index], "permissions_boundary", "")}"
+  permissions_boundary = lookup(var.permissions_boundaries, each.key, "")
 
   # Allow session for X seconds
-  max_session_duration  = "${var.max_session_duration}"
-  force_detach_policies = "${var.force_detach_policies}"
+  max_session_duration  = var.max_session_duration
+  force_detach_policies = var.force_detach_policies
 
-  tags = "${merge(
-    map("Name", lookup(var.roles[count.index], "name")),
+  tags = merge(
+    map("Name", lookup(each.value, "name")),
     var.tags
-  )}"
+  )
+
 }
 
-# ------------------------------------------------------------------------------------------------
-# Create Policies for above Roles
-# ------------------------------------------------------------------------------------------------
 
-resource "aws_iam_policy" "policies" {
-  count = "${var.role_count}"
-
-  name        = "${lookup(var.roles[count.index], "policy_name")}"
-  path        = "${lookup(var.roles[count.index], "policy_path", "") == "" ? var.policy_path : lookup(var.roles[count.index], "policy_path")}"
-  description = "${lookup(var.roles[count.index], "policy_desc", "") == "" ? var.policy_desc : lookup(var.roles[count.index], "policy_desc")}"
-
-  # This defines what permissions our role will be given
-  policy = "${file(lookup(var.roles[count.index], "policy_file"))}"
-}
-
-# ------------------------------------------------------------------------------------------------
+# -------------------------------------------------------------------------------------------------
 # Attach Policies to Role
-# ------------------------------------------------------------------------------------------------
-# IMPORTANT: https://www.terraform.io/docs/providers/aws/r/iam_policy_attachment.html
+# -------------------------------------------------------------------------------------------------
 
-# Exclusive attachment of roles
-resource "aws_iam_policy_attachment" "exclusive_policy_attachment" {
-  count = "${var.exclusive_policy_attachment ? var.role_count : 0}"
+# Attach customer managed policies
+resource "aws_iam_role_policy_attachment" "policy_attachments" {
+  for_each = local.role_policies
 
-  name       = "${lookup(var.roles[count.index], "policy_name")}"
-  roles      = ["${element(aws_iam_role.roles.*.name, count.index)}"]
-  policy_arn = "${aws_iam_policy.policies.*.arn[count.index]}"
+  role       = replace(each.key, format(":%s", each.value.name), "")
+  policy_arn = aws_iam_policy.policies[each.value.name].arn
+
+  # Terraform has no info that aws_iam_roles and aws_iam_policies
+  # must be run first in order to create the roles,
+  # so we must explicitly tell it.
+  depends_on = [
+    aws_iam_role.roles,
+    aws_iam_policy.policies,
+  ]
 }
 
-# Additive adding of roles
-resource "aws_iam_role_policy_attachment" "imperative_policy_attachment" {
-  count = "${var.exclusive_policy_attachment ? 0 : var.role_count}"
+# Attach policy ARNs
+resource "aws_iam_role_policy_attachment" "policy_arn_attachments" {
+  for_each = local.policy_arns
 
-  role       = "${element(aws_iam_role.roles.*.name, count.index)}"
-  policy_arn = "${aws_iam_policy.policies.*.arn[count.index]}"
+  role       = replace(each.key, format(":%s", each.value), "")
+  policy_arn = each.value
+
+  # Terraform has no info that aws_iam_roles must be run first in order to create the roles,
+  # so we must explicitly tell it.
+  depends_on = [aws_iam_role.roles]
+}
+
+# Attach inline policies
+resource "aws_iam_role_policy" "inline_policy_attachments" {
+  for_each = local.inline_policies
+
+  name   = each.value.name
+  role   = replace(each.key, format(":%s", each.value.name), "")
+  policy = templatefile(lookup(each.value, "file"), lookup(each.value, "vars"))
+
+  # Terraform has no info that aws_iam_roles must be run first in order to create the roles,
+  # so we must explicitly tell it.
+  depends_on = [aws_iam_role.roles]
 }

--- a/main.tf
+++ b/main.tf
@@ -17,8 +17,8 @@ resource "aws_iam_policy" "policies" {
   for_each = local.policies
 
   name        = lookup(each.value, "name")
-  path        = lookup(each.value, "path", "") == "" ? var.policy_path : lookup(each.value, "path")
-  description = lookup(each.value, "desc", "") == "" ? var.policy_desc : lookup(each.value, "desc")
+  path        = lookup(each.value, "path", null) == null ? var.policy_path : lookup(each.value, "path")
+  description = lookup(each.value, "desc", null) == null ? var.policy_desc : lookup(each.value, "desc")
   policy      = templatefile(lookup(each.value, "file"), lookup(each.value, "vars"))
 }
 
@@ -32,8 +32,8 @@ resource "aws_iam_role" "roles" {
   for_each = { for role in var.roles : role.name => role }
 
   name        = lookup(each.value, "name")
-  path        = lookup(each.value, "path", "") == "" ? var.role_path : lookup(each.value, "path")
-  description = lookup(each.value, "desc", "") == "" ? var.role_desc : lookup(each.value, "desc")
+  path        = lookup(each.value, "path", null) == null ? var.role_path : lookup(each.value, "path")
+  description = lookup(each.value, "desc", null) == null ? var.role_desc : lookup(each.value, "desc")
 
   # This policy defines who/what is allowed to use the current role
   assume_role_policy = file(lookup(each.value, "trust_policy_file"))

--- a/outputs.tf
+++ b/outputs.tf
@@ -1,115 +1,72 @@
 # -------------------------------------------------------------------------------------------------
-# IAM Role outputs
+# Input variables
 # -------------------------------------------------------------------------------------------------
 
-output "roles" {
+output "var_roles" {
   description = "The defined roles list"
-  value       = "${var.roles}"
+  value       = var.roles
 }
 
-output "role_ids" {
-  description = "The stable and unique string identifying the role."
-  value       = ["${aws_iam_role.roles.*.unique_id}"]
+output "var_permissions_boundaries" {
+  description = "The defined roles list"
+  value       = var.permissions_boundaries
 }
 
-output "role_arns" {
-  description = "The Amazon Resource Name (ARN) specifying the role."
-  value       = ["${aws_iam_role.roles.*.arn}"]
-}
-
-output "role_names" {
-  description = "The name of the role."
-  value       = ["${aws_iam_role.roles.*.name}"]
-}
-
-output "role_paths" {
-  description = "The path to the role."
-  value       = ["${aws_iam_role.roles.*.path}"]
-}
-
-output "role_session_durations" {
-  description = "The maximum session duration (in seconds) that you want to set for the specified role. This setting can have a value from 1 hour to 12 hours."
-  value       = ["${aws_iam_role.roles.*.max_session_duration}"]
-}
-
-output "role_force_detach_policies" {
-  description = "Specifies to force detaching any policies the role has before destroying it."
-  value       = ["${aws_iam_role.roles.*.force_detach_policies}"]
-}
-
-output "role_policies" {
-  description = "A list of the policy definitions."
-  value       = ["${aws_iam_policy.policies.*.policy}"]
-}
-
-output "role_assume_policies" {
-  description = "A list of the policy definitions."
-  value       = ["${aws_iam_role.roles.*.assume_role_policy}"]
+output "var_policies" {
+  description = "The transformed policy map"
+  value       = var.policies
 }
 
 # -------------------------------------------------------------------------------------------------
-# IAM Policy outputs
+# Transformed variables
 # -------------------------------------------------------------------------------------------------
 
-output "policy_arns" {
-  description = "A list of ARN assigned by AWS to the policies."
-  value       = ["${aws_iam_policy.policies.*.arn}"]
+output "local_policies" {
+  description = "The transformed policy map"
+  value       = local.policies
 }
 
-output "policy_ids" {
-  description = "A list of unique IDs of the policies."
-  value       = ["${aws_iam_policy.policies.*.id}"]
+output "local_role_policies" {
+  description = "The transformed role policy map"
+  value       = local.role_policies
 }
 
-output "policy_names" {
-  description = "A list of names of the policies."
-  value       = ["${aws_iam_policy.policies.*.name}"]
+output "local_inline_policies" {
+  description = "The transformed inline policy map"
+  value       = local.inline_policies
 }
 
-output "policy_paths" {
-  description = "A list of paths of the policies."
-  value       = ["${aws_iam_policy.policies.*.path}"]
+output "local_policy_arns" {
+  description = "The transformed policy arns map"
+  value       = local.policy_arns
 }
+
 
 # -------------------------------------------------------------------------------------------------
-# IAM Policy attachments (exclusive)
+# Created resources
 # -------------------------------------------------------------------------------------------------
 
-output "exclusive_policy_attachment_ids" {
-  description = "A list of unique IDs of exclusive policy attachments."
-  value       = ["${aws_iam_policy_attachment.exclusive_policy_attachment.*.id}"]
+output "created_roles" {
+  description = "Created IAM roles"
+  value       = aws_iam_role.roles
 }
 
-output "exclusive_policy_attachment_names" {
-  description = "A list of names of exclusive policy attachments."
-  value       = ["${aws_iam_policy_attachment.exclusive_policy_attachment.*.name}"]
+output "created_policies" {
+  description = "Created customer managed IAM policies"
+  value       = aws_iam_policy.policies
 }
 
-output "exclusive_policy_attachment_policy_arns" {
-  description = "A list of ARNs of exclusive policy attachments."
-  value       = ["${aws_iam_policy_attachment.exclusive_policy_attachment.*.policy_arn}"]
+output "created_policy_attachments" {
+  description = "Attached customer managed IAM policies"
+  value       = aws_iam_role_policy_attachment.policy_attachments
 }
 
-output "exclusive_policy_attachment_role_names" {
-  description = "A list of role names of exclusive policy attachments."
-  value       = ["${aws_iam_policy_attachment.exclusive_policy_attachment.*.roles}"]
+output "created_inline_policy_attachments" {
+  description = "Attached inline IAM policies"
+  value       = aws_iam_role_policy.inline_policy_attachments
 }
 
-# -------------------------------------------------------------------------------------------------
-# IAM Policy attachments (imperative)
-# -------------------------------------------------------------------------------------------------
-
-output "imperative_policy_attachment_ids" {
-  description = "A list of unique IDs of shared policy attachments."
-  value       = ["${aws_iam_role_policy_attachment.imperative_policy_attachment.*.id}"]
-}
-
-output "imperative_policy_attachment_policy_arns" {
-  description = "A list of ARNs of shared policy attachments."
-  value       = ["${aws_iam_role_policy_attachment.imperative_policy_attachment.*.policy_arn}"]
-}
-
-output "imperative_policy_attachment_role_names" {
-  description = "A list of role names of shared policy attachments."
-  value       = ["${aws_iam_role_policy_attachment.imperative_policy_attachment.*.role}"]
+output "created_policy_arn_attachments" {
+  description = "Attached IAM policy arns"
+  value       = aws_iam_role_policy_attachment.policy_arn_attachments
 }

--- a/variables.tf
+++ b/variables.tf
@@ -27,8 +27,8 @@ variable "policies" {
   description = "A list of dictionaries defining all roles."
   type = list(object({
     name = string      # Name of the policy
-    path = string      # Defaults to 'var.policy_path' variable if empty
-    desc = string      # Defaults to 'var.policy_desc' variable if empty
+    path = string      # Defaults to 'var.policy_path' variable is set to null
+    desc = string      # Defaults to 'var.policy_desc' variable is set to null
     file = string      # Path to json or json.tmpl file of policy
     vars = map(string) # Policy template variables {key: val, ...}
   }))
@@ -73,8 +73,8 @@ variable "roles" {
   description = "A list of dictionaries defining all roles."
   type = list(object({
     name              = string       # Name of the role
-    path              = string       # Defaults to 'var.role_path' variable if empty
-    desc              = string       # Defaults to 'var.role_desc' variable if empty
+    path              = string       # Defaults to 'var.role_path' variable is set to null
+    desc              = string       # Defaults to 'var.role_desc' variable is set to null
     trust_policy_file = string       # Path to file of trust/assume policy
     policies          = list(string) # List of names of policies (must be defined in var.policies)
     inline_policies = list(object({


### PR DESCRIPTION
# Terraform 0.12 version

This PR migrates the project to TF >= 0.12.

## Additional features:

* Policies are in a separate list to allow for re-using them in multiple roles
* Inline policies can be added
* Pre-defined policies can be added via ARN's
* Permissions boundary can be defined on a per role base

## Tagging

As this is a non-backwords compatible release, the major version must be bumped. New tag will be: `v2.0.0`