### PR TITLE
Add user management

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -12,8 +12,8 @@ TF_MODULES  = $(sort $(dir $(wildcard $(CURRENT_DIR)modules/*/)))
 # Container versions
 # -------------------------------------------------------------------------------------------------
 TF_VERSION      = light
-TFDOCS_VERSION  = 0.6.0
-FL_VERSION      = 0.2
+TFDOCS_VERSION  = 0.10.1
+FL_VERSION      = 0.3
 JL_VERSION      = latest-0.4
 
 
@@ -32,7 +32,7 @@ LINT_JL_ENABLE = 1
 DELIM_START = <!-- BEGINNING OF PRE-COMMIT-TERRAFORM DOCS HOOK -->
 DELIM_CLOSE = <!-- END OF PRE-COMMIT-TERRAFORM DOCS HOOK -->
 # What arguments to append to terraform-docs command
-TFDOCS_ARGS = --sort-inputs-by-required --with-aggregate-type-defaults
+TFDOCS_ARGS = --sort-by-required
 
 
 # -------------------------------------------------------------------------------------------------

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@
 [![License](https://img.shields.io/badge/license-MIT-blue.svg)](https://opensource.org/licenses/MIT)
 
 This Terraform module can create an arbitrary number of IAM users, roles and policies. Roles can additionally be created with inline policies or policy ARN's attached and with trusted
-entities defined as JSON or templatable json files files. Users can also additionally be created with inline policies or policy ARN's attached.
+entities defined as JSON or templatable json files files. Users can also additionally be created with inline policies or policy ARN's attached as well as their access key rotation can be fully managed.
 
 
 ## Important note
@@ -42,30 +42,28 @@ module "iam_roles" {
   # List of users to manage
   users = [
     {
-      name       = "cytopia"
-      path       = null
-      access_key = {
-        create  = true
-        pgp_key = ""
-        status  = "Active"
-      }
-      policies = [
-        "rds-authenticate",
-      ]
+      name            = "admin"
+      path            = null
+      access_keys     = []
+      policies        = []
       inline_policies = []
       policy_arns = [
         "arn:aws:iam::aws:policy/AdministratorAccess",
       ]
     },
     {
-      name       = "developer"
-      path       = null
-      access_key = {
-        create  = false
-        pgp_key = ""
-        status  = ""
-      }
-      policies        = []
+      name        = "developer"
+      path        = null
+      access_keys = [
+        {
+          name    = "key-1"
+          pgp_key = ""
+          status  = "Active"
+        }
+      ]
+      policies    = [
+        "rds-authenticate",
+      ]
       inline_policies = []
       policy_arns     = []
     },
@@ -188,7 +186,7 @@ Defines the permissions (Authorization)
 | Name | Description | Type | Default | Required |
 |------|-------------|------|---------|:--------:|
 | roles | A list of dictionaries defining all roles. | <pre>list(object({<br>    name              = string       # Name of the role<br>    path              = string       # Defaults to 'var.role_path' variable is set to null<br>    desc              = string       # Defaults to 'var.role_desc' variable is set to null<br>    trust_policy_file = string       # Path to file of trust/assume policy<br>    policies          = list(string) # List of names of policies (must be defined in var.policies)<br>    inline_policies = list(object({<br>      name = string      # Name of the inline policy<br>      file = string      # Path to json or json.tmpl file of policy<br>      vars = map(string) # Policy template variables {key = val, ...}<br>    }))<br>    policy_arns = list(string) # List of existing policy ARN's<br>  }))</pre> | n/a | yes |
-| users | A list of dictionaries defining all users. | <pre>list(object({<br>    name       = string  # Name of the user<br>    path       = string  # Defaults to 'var.user_path' variable is set to null<br>    access_key = object({<br>      create  = bool     # Create Access key and secret?<br>      pgp_key = string   # Leave empty for non or provide a b64-enc pubkey or keybase username<br>      status  = string   # 'Active' or 'Inactive'<br>    })<br>    policies = list(string) # List of names of policies (must be defined in var.policies)<br>    inline_policies = list(object({<br>      name = string      # Name of the inline policy<br>      file = string      # Path to json or json.tmpl file of policy<br>      vars = map(string) # Policy template variables {key = val, ...}<br>    }))<br>    policy_arns = list(string) # List of existing policy ARN's<br>  }))</pre> | n/a | yes |
+| users | A list of dictionaries defining all users. | <pre>list(object({<br>    name = string # Name of the user<br>    path = string # Defaults to 'var.user_path' variable is set to null<br>    access_keys = list(object({<br>      name    = string # IaC identifier for first or second IAM access key (not used on AWS)<br>      pgp_key = string # Leave empty for non or provide a b64-enc pubkey or keybase username<br>      status  = string # 'Active' or 'Inactive'<br>    }))<br>    policies = list(string) # List of names of policies (must be defined in var.policies)<br>    inline_policies = list(object({<br>      name = string      # Name of the inline policy<br>      file = string      # Path to json or json.tmpl file of policy<br>      vars = map(string) # Policy template variables {key = val, ...}<br>    }))<br>    policy_arns = list(string) # List of existing policy ARN's<br>  }))</pre> | n/a | yes |
 | permissions\_boundaries | A map of strings containing ARN's of policies to attach as permissions boundaries to roles. | `map(string)` | `{}` | no |
 | policies | A list of dictionaries defining all policies. | <pre>list(object({<br>    name = string      # Name of the policy<br>    path = string      # Defaults to 'var.policy_path' variable is set to null<br>    desc = string      # Defaults to 'var.policy_desc' variable is set to null<br>    file = string      # Path to json or json.tmpl file of policy<br>    vars = map(string) # Policy template variables {key: val, ...}<br>  }))</pre> | `[]` | no |
 | policy\_desc | The default description of the policy. | `string` | `"Managed by Terraform"` | no |

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# Terraform module: AWS IAM Roles
+# Terraform module: AWS IAM
 
 [![Build Status](https://travis-ci.org/cytopia/terraform-aws-iam-roles.svg?branch=master)](https://travis-ci.org/cytopia/terraform-aws-iam-roles)
 [![Tag](https://img.shields.io/github/tag/cytopia/terraform-aws-iam-roles.svg)](https://github.com/cytopia/terraform-aws-iam-roles/releases)
@@ -133,37 +133,59 @@ Defines the permissions (Authorization)
 
 
 <!-- BEGINNING OF PRE-COMMIT-TERRAFORM DOCS HOOK -->
+## Requirements
+
+| Name | Version |
+|------|---------|
+| terraform | >= 0.12.6 |
+
+## Providers
+
+| Name | Version |
+|------|---------|
+| aws | n/a |
+
 ## Inputs
 
 | Name | Description | Type | Default | Required |
-|------|-------------|:----:|:-----:|:-----:|
-| roles | A list of dictionaries defining all roles. | object | n/a | yes |
-| force\_detach\_policies | Specifies to force detaching any policies the role has before destroying it. | string | `"true"` | no |
-| max\_session\_duration | The maximum session duration (in seconds) that you want to set for the specified role. This setting can have a value from 1 hour to 12 hours specified in seconds. | string | `"3600"` | no |
-| permissions\_boundaries | A map of strings containing ARN's of policies to attach as permissions boundaries to roles. | map(string) | `{}` | no |
-| policies | A list of dictionaries defining all roles. | object | `[]` | no |
-| policy\_desc | The default description of the policy. | string | `"Managed by Terraform"` | no |
-| policy\_path | The default path under which to create the policy if not specified in the policies list. You can use a single path, or nest multiple paths as if they were a folder structure. For example, you could use the nested path /division_abc/subdivision_xyz/product_1234/engineering/ to match your company's organizational structure. | string | `"/"` | no |
-| role\_desc | The description of the role. | string | `"Managed by Terraform"` | no |
-| role\_path | The path under which to create the role. You can use a single path, or nest multiple paths as if they were a folder structure. For example, you could use the nested path /division_abc/subdivision_xyz/product_1234/engineering/ to match your company's organizational structure. | string | `"/"` | no |
-| tags | Key-value mapping of tags for the IAM role. | map | `{}` | no |
+|------|-------------|------|---------|:--------:|
+| roles | A list of dictionaries defining all roles. | <pre>list(object({<br>    name              = string       # Name of the role<br>    path              = string       # Defaults to 'var.role_path' variable is set to null<br>    desc              = string       # Defaults to 'var.role_desc' variable is set to null<br>    trust_policy_file = string       # Path to file of trust/assume policy<br>    policies          = list(string) # List of names of policies (must be defined in var.policies)<br>    inline_policies = list(object({<br>      name = string      # Name of the inline policy<br>      file = string      # Path to json or json.tmpl file of policy<br>      vars = map(string) # Policy template variables {key = val, ...}<br>    }))<br>    policy_arns = list(string) # List of existing policy ARN's<br>  }))</pre> | n/a | yes |
+| users | A list of dictionaries defining all users. | <pre>list(object({<br>    name     = string       # Name of the user<br>    path     = string       # Defaults to 'var.user_path' variable is set to null<br>    policies = list(string) # List of names of policies (must be defined in var.policies)<br>    inline_policies = list(object({<br>      name = string      # Name of the inline policy<br>      file = string      # Path to json or json.tmpl file of policy<br>      vars = map(string) # Policy template variables {key = val, ...}<br>    }))<br>    policy_arns = list(string) # List of existing policy ARN's<br>  }))</pre> | n/a | yes |
+| permissions\_boundaries | A map of strings containing ARN's of policies to attach as permissions boundaries to roles. | `map(string)` | `{}` | no |
+| policies | A list of dictionaries defining all policies. | <pre>list(object({<br>    name = string      # Name of the policy<br>    path = string      # Defaults to 'var.policy_path' variable is set to null<br>    desc = string      # Defaults to 'var.policy_desc' variable is set to null<br>    file = string      # Path to json or json.tmpl file of policy<br>    vars = map(string) # Policy template variables {key: val, ...}<br>  }))</pre> | `[]` | no |
+| policy\_desc | The default description of the policy. | `string` | `"Managed by Terraform"` | no |
+| policy\_path | The default path under which to create the policy if not specified in the policies list. You can use a single path, or nest multiple paths as if they were a folder structure. For example, you could use the nested path /division\_abc/subdivision\_xyz/product\_1234/engineering/ to match your company's organizational structure. | `string` | `"/"` | no |
+| role\_desc | The description of the role. | `string` | `"Managed by Terraform"` | no |
+| role\_force\_detach\_policies | Specifies to force detaching any policies the role has before destroying it. | `bool` | `true` | no |
+| role\_max\_session\_duration | The maximum session duration (in seconds) that you want to set for the specified role. This setting can have a value from 1 hour to 12 hours specified in seconds. | `string` | `"3600"` | no |
+| role\_path | The path under which to create the role. You can use a single path, or nest multiple paths as if they were a folder structure. For example, you could use the nested path /division\_abc/subdivision\_xyz/product\_1234/engineering/ to match your company's organizational structure. | `string` | `"/"` | no |
+| tags | Key-value mapping of tags for the IAM role or user. | `map(any)` | `{}` | no |
+| user\_path | The path under which to create the user. You can use a single path, or nest multiple paths as if they were a folder structure. For example, you could use the nested path /division\_abc/subdivision\_xyz/product\_1234/engineering/ to match your company's organizational structure. | `string` | `"/"` | no |
 
 ## Outputs
 
 | Name | Description |
 |------|-------------|
-| created\_inline\_policy\_attachments | Attached inline IAM policies |
 | created\_policies | Created customer managed IAM policies |
-| created\_policy\_arn\_attachments | Attached IAM policy arns |
-| created\_policy\_attachments | Attached customer managed IAM policies |
+| created\_role\_inline\_policy\_attachments | Attached role inline IAM policies |
+| created\_role\_policy\_arn\_attachments | Attached role IAM policy arns |
+| created\_role\_policy\_attachments | Attached role customer managed IAM policies |
 | created\_roles | Created IAM roles |
-| local\_inline\_policies | The transformed inline policy map |
+| created\_user\_inline\_policy\_attachments | Attached user inline IAM policies |
+| created\_user\_policy\_arn\_attachments | Attached user IAM policy arns |
+| created\_user\_policy\_attachments | Attached user customer managed IAM policies |
+| created\_users | Created IAM users |
 | local\_policies | The transformed policy map |
-| local\_policy\_arns | The transformed policy arns map |
+| local\_role\_inline\_policies | The transformed role inline policy map |
 | local\_role\_policies | The transformed role policy map |
+| local\_role\_policy\_arns | The transformed role policy arns map |
+| local\_user\_inline\_policies | The transformed user inline policy map |
+| local\_user\_policies | The transformed user policy map |
+| local\_user\_policy\_arns | The transformed user policy arns map |
 | var\_permissions\_boundaries | The defined roles list |
 | var\_policies | The transformed policy map |
 | var\_roles | The defined roles list |
+| var\_users | The defined users list |
 
 <!-- END OF PRE-COMMIT-TERRAFORM DOCS HOOK -->
 

--- a/README.md
+++ b/README.md
@@ -9,6 +9,12 @@ This Terraform module can create an arbitrary number of IAM roles with policies 
 entities defined as JSON or templatable json files files.
 
 
+## Important note
+
+When creating an IAM user with an `Inactive` access key it is initially create with access key set to `Active`. You will have to run it a second time in order to deactivate the access key.
+This is either an issue with the terraform resource `aws_iam_access_key` or with the AWS api itself.
+
+
 ## Usage
 
 ### Assumeable roles
@@ -150,7 +156,7 @@ Defines the permissions (Authorization)
 | Name | Description | Type | Default | Required |
 |------|-------------|------|---------|:--------:|
 | roles | A list of dictionaries defining all roles. | <pre>list(object({<br>    name              = string       # Name of the role<br>    path              = string       # Defaults to 'var.role_path' variable is set to null<br>    desc              = string       # Defaults to 'var.role_desc' variable is set to null<br>    trust_policy_file = string       # Path to file of trust/assume policy<br>    policies          = list(string) # List of names of policies (must be defined in var.policies)<br>    inline_policies = list(object({<br>      name = string      # Name of the inline policy<br>      file = string      # Path to json or json.tmpl file of policy<br>      vars = map(string) # Policy template variables {key = val, ...}<br>    }))<br>    policy_arns = list(string) # List of existing policy ARN's<br>  }))</pre> | n/a | yes |
-| users | A list of dictionaries defining all users. | <pre>list(object({<br>    name     = string       # Name of the user<br>    path     = string       # Defaults to 'var.user_path' variable is set to null<br>    policies = list(string) # List of names of policies (must be defined in var.policies)<br>    inline_policies = list(object({<br>      name = string      # Name of the inline policy<br>      file = string      # Path to json or json.tmpl file of policy<br>      vars = map(string) # Policy template variables {key = val, ...}<br>    }))<br>    policy_arns = list(string) # List of existing policy ARN's<br>  }))</pre> | n/a | yes |
+| users | A list of dictionaries defining all users. | <pre>list(object({<br>    name       = string  # Name of the user<br>    path       = string  # Defaults to 'var.user_path' variable is set to null<br>    access_key = object({<br>      create  = bool     # Create Access key and secret?<br>      pgp_key = string   # Leave empty for non or provide a b64-enc pubkey or keybase username<br>      status  = string   # 'Active' or 'Inactive'<br>    })<br>    policies = list(string) # List of names of policies (must be defined in var.policies)<br>    inline_policies = list(object({<br>      name = string      # Name of the inline policy<br>      file = string      # Path to json or json.tmpl file of policy<br>      vars = map(string) # Policy template variables {key = val, ...}<br>    }))<br>    policy_arns = list(string) # List of existing policy ARN's<br>  }))</pre> | n/a | yes |
 | permissions\_boundaries | A map of strings containing ARN's of policies to attach as permissions boundaries to roles. | `map(string)` | `{}` | no |
 | policies | A list of dictionaries defining all policies. | <pre>list(object({<br>    name = string      # Name of the policy<br>    path = string      # Defaults to 'var.policy_path' variable is set to null<br>    desc = string      # Defaults to 'var.policy_desc' variable is set to null<br>    file = string      # Path to json or json.tmpl file of policy<br>    vars = map(string) # Policy template variables {key: val, ...}<br>  }))</pre> | `[]` | no |
 | policy\_desc | The default description of the policy. | `string` | `"Managed by Terraform"` | no |

--- a/README.md
+++ b/README.md
@@ -172,26 +172,27 @@ Defines the permissions (Authorization)
 
 | Name | Description |
 |------|-------------|
-| created\_policies | Created customer managed IAM policies |
-| created\_role\_inline\_policy\_attachments | Attached role inline IAM policies |
-| created\_role\_policy\_arn\_attachments | Attached role IAM policy arns |
-| created\_role\_policy\_attachments | Attached role customer managed IAM policies |
-| created\_roles | Created IAM roles |
-| created\_user\_inline\_policy\_attachments | Attached user inline IAM policies |
-| created\_user\_policy\_arn\_attachments | Attached user IAM policy arns |
-| created\_user\_policy\_attachments | Attached user customer managed IAM policies |
-| created\_users | Created IAM users |
-| local\_policies | The transformed policy map |
-| local\_role\_inline\_policies | The transformed role inline policy map |
-| local\_role\_policies | The transformed role policy map |
-| local\_role\_policy\_arns | The transformed role policy arns map |
-| local\_user\_inline\_policies | The transformed user inline policy map |
-| local\_user\_policies | The transformed user policy map |
-| local\_user\_policy\_arns | The transformed user policy arns map |
-| var\_permissions\_boundaries | The defined roles list |
-| var\_policies | The transformed policy map |
-| var\_roles | The defined roles list |
-| var\_users | The defined users list |
+| debug\_local\_policies | The transformed policy map |
+| debug\_local\_role\_inline\_policies | The transformed role inline policy map |
+| debug\_local\_role\_policies | The transformed role policy map |
+| debug\_local\_role\_policy\_arns | The transformed role policy arns map |
+| debug\_local\_user\_access\_keys | The transformed user access key map |
+| debug\_local\_user\_inline\_policies | The transformed user inline policy map |
+| debug\_local\_user\_policies | The transformed user policy map |
+| debug\_local\_user\_policy\_arns | The transformed user policy arns map |
+| debug\_var\_permissions\_boundaries | The defined roles list |
+| debug\_var\_policies | The transformed policy map |
+| debug\_var\_roles | The defined roles list |
+| debug\_var\_users | The defined users list |
+| policies | Created customer managed IAM policies |
+| role\_inline\_policy\_attachments | Attached role inline IAM policies |
+| role\_policy\_arn\_attachments | Attached role IAM policy arns |
+| role\_policy\_attachments | Attached role customer managed IAM policies |
+| roles | Created IAM roles |
+| user\_inline\_policy\_attachments | Attached user inline IAM policies |
+| user\_policy\_arn\_attachments | Attached user IAM policy arns |
+| user\_policy\_attachments | Attached user customer managed IAM policies |
+| users | Created IAM users |
 
 <!-- END OF PRE-COMMIT-TERRAFORM DOCS HOOK -->
 

--- a/README.md
+++ b/README.md
@@ -5,8 +5,8 @@
 [![Terraform](https://img.shields.io/badge/Terraform--registry-aws--iam--roles-brightgreen.svg)](https://registry.terraform.io/modules/cytopia/iam-roles/aws/)
 [![License](https://img.shields.io/badge/license-MIT-blue.svg)](https://opensource.org/licenses/MIT)
 
-This Terraform module can create an arbitrary number of IAM roles with policies and trusted
-entities defined as JSON or templatable json files files.
+This Terraform module can create an arbitrary number of IAM users, roles and policies. Roles can additionally be created with inline policies or policy ARN's attached and with trusted
+entities defined as JSON or templatable json files files. Users can also additionally be created with inline policies or policy ARN's attached.
 
 
 ## Important note
@@ -38,6 +38,38 @@ module "iam_roles" {
   permissions_boundaries = {
     "ROLE-DEV" = "arn:aws:iam::*:policy/perm-boundaries/default"
   }
+
+  # List of users to manage
+  users = [
+    {
+      name       = "cytopia"
+      path       = null
+      access_key = {
+        create  = true
+        pgp_key = ""
+        status  = "Active"
+      }
+      policies = [
+        "rds-authenticate",
+      ]
+      inline_policies = []
+      policy_arns = [
+        "arn:aws:iam::aws:policy/AdministratorAccess",
+      ]
+    },
+    {
+      name       = "developer"
+      path       = null
+      access_key = {
+        create  = false
+        pgp_key = ""
+        status  = ""
+      }
+      policies        = []
+      inline_policies = []
+      policy_arns     = []
+    },
+  ]
 
   # List of roles to manage
   roles = [

--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ entities defined as JSON or templatable json files files. Users can also additio
 
 ## Important note
 
-When creating an IAM user with an `Inactive` access key it is initially create with access key set to `Active`. You will have to run it a second time in order to deactivate the access key.
+When creating an IAM user with an `Inactive` access key it is initially created with access key set to `Active`. You will have to run it a second time in order to deactivate the access key.
 This is either an issue with the terraform resource `aws_iam_access_key` or with the AWS api itself.
 
 

--- a/locals.tf
+++ b/locals.tf
@@ -109,7 +109,7 @@ locals {
       }
     ]
   ])
-  user_policies = { for obj in local.rp : "${obj.user_name}:${obj.policy_name}" => obj.policy }
+  user_policies = { for obj in local.up : "${obj.user_name}:${obj.policy_name}" => obj.policy }
 }
 
 

--- a/locals.tf
+++ b/locals.tf
@@ -53,6 +53,29 @@ locals {
 
 
 # -------------------------------------------------------------------------------------------------
+# User Access key transformations
+# -------------------------------------------------------------------------------------------------
+
+locals {
+  # [user_access_keys]
+  # This local transforms users into a useable user_access_keys list
+  #
+  # user_access_keys = {
+  #   "<user-name>" = {
+  #     create  = true|false
+  #     pgp_key = "<pgp-key>"        # or empty
+  #     status  = "Active|Inactive"  # or empty
+  #   },
+  #   "<user-name>" = {
+  #     create  = true|false
+  #     pgp_key = "<pgp-key>"        # or empty
+  #     status  = "Active|Inactive"  # or empty
+  #   }
+  # }
+  user_access_keys = { for u in var.users : u["name"] => u["access_key"] if u["access_key"]["create"] }
+}
+
+# -------------------------------------------------------------------------------------------------
 # Role/User Policy transformations
 # -------------------------------------------------------------------------------------------------
 

--- a/locals.tf
+++ b/locals.tf
@@ -60,19 +60,35 @@ locals {
   # [user_access_keys]
   # This local transforms users into a useable user_access_keys list
   #
-  # user_access_keys = {
-  #   "<user-name>" = {
-  #     create  = true|false
-  #     pgp_key = "<pgp-key>"        # or empty
-  #     status  = "Active|Inactive"  # or empty
+  # user_access_keys = [
+  #   {
+  #     "<user-name>:<key-name>" = {
+  #       user_name  = "<user-name>"      # required to distinguish between one of the two keys
+  #       key_name   = "<key-name>"       # required to distinguish between one of the two keys
+  #       pgp_key    = "<pgp-key>"        # or empty
+  #       status     = "Active|Inactive"  # or empty
+  #     },
   #   },
-  #   "<user-name>" = {
-  #     create  = true|false
-  #     pgp_key = "<pgp-key>"        # or empty
-  #     status  = "Active|Inactive"  # or empty
-  #   }
-  # }
-  user_access_keys = { for u in var.users : u["name"] => u["access_key"] if u["access_key"]["create"] }
+  #   {
+  #     "<user-name>:<key-name>" = {
+  #       user_name  = "<user-name>"      # required to distinguish between one of the two keys
+  #       key_name   = "<key-name>"       # required to distinguish between one of the two keys
+  #       pgp_key    = "<pgp-key>"        # or empty
+  #       status     = "Active|Inactive"  # or empty
+  #     },
+  #   },
+  # ]
+  uak = flatten([
+    for user in var.users : [
+      for user_access_key in user["access_keys"] : {
+        user_name = user.name
+        key_name  = user_access_key.name
+        pgp_key   = user_access_key.pgp_key
+        status    = user_access_key.status
+      }
+    ]
+  ])
+  user_access_keys = { for obj in local.uak : "${obj.user_name}:${obj.key_name}" => obj }
 }
 
 # -------------------------------------------------------------------------------------------------

--- a/locals.tf
+++ b/locals.tf
@@ -53,11 +53,11 @@ locals {
 
 
 # -------------------------------------------------------------------------------------------------
-# Role Policy transformations
+# Role/User Policy transformations
 # -------------------------------------------------------------------------------------------------
 
 locals {
-
+  # [role_policies]
   # This local combines var.roles and var.policies and creates its own list as shown below:
   #
   # role_policies = [
@@ -82,20 +82,47 @@ locals {
       }
     ]
   ])
-
   role_policies = { for obj in local.rp : "${obj.role_name}:${obj.policy_name}" => obj.policy }
+
+  # [user_policies]
+  # This local combines var.users and var.policies and creates its own list as shown below:
+  #
+  # user_policies = [
+  #   {
+  #     "<user-name>:<policy-name>" = {
+  #       name = "<policy-name>"
+  #       path = "<policy-path>"
+  #       desc = "<policy-desc>"
+  #       file = "<policy-file>"
+  #       vars = {
+  #         key = "val",
+  #       }
+  #     }
+  #   },
+  # ]
+  up = flatten([
+    for user in var.users : [
+      for policy in user["policies"] : {
+        user_name   = user.name
+        policy_name = policy
+        policy      = local.policies[policy]
+      }
+    ]
+  ])
+  user_policies = { for obj in local.rp : "${obj.user_name}:${obj.policy_name}" => obj.policy }
 }
 
 
 # -------------------------------------------------------------------------------------------------
-# Inline Policy transformations
+# Role/User Inline Policy transformations
 # -------------------------------------------------------------------------------------------------
 
 locals {
-  # This local extracts inline_policies from var.roles and combines the found policies
+  # [role_inline_policies]
+  # This local extracts inline_role_policies from var.roles and combines the found policies
   # with the role names as shown below:
   #
-  # inline_policies = [
+  # role_inline_policies = [
   #   {
   #     "<role-name>:<policy-name>" = {
   #       name = "<policy-name>"
@@ -115,7 +142,7 @@ locals {
   #     }
   #   },
   # ]
-  ip = flatten([
+  rip = flatten([
     for role in var.roles : [
       for inline_policy in role["inline_policies"] : {
         role_name   = role.name
@@ -124,20 +151,54 @@ locals {
       }
     ]
   ])
+  role_inline_policies = { for obj in local.rip : "${obj.role_name}:${obj.policy_name}" => obj.policy }
 
-  inline_policies = { for obj in local.ip : "${obj.role_name}:${obj.policy_name}" => obj.policy }
+  # [user_inline_policies]
+  # This local extracts inline_user_policies from var.users and combines the found policies
+  # with the user names as shown below:
+  #
+  # user_inline_policies = [
+  #   {
+  #     "<user-name>:<policy-name>" = {
+  #       name = "<policy-name>"
+  #       file = "<policy-file>"
+  #       vars = {
+  #         key = "val",
+  #       }
+  #     }
+  #   },
+  #   {
+  #     "<user-name>:<policy-name>" = {
+  #       name = "<policy-name>"
+  #       file = "<policy-file>"
+  #       vars = {
+  #         key = "val",
+  #       }
+  #     }
+  #   },
+  # ]
+  uip = flatten([
+    for user in var.users : [
+      for inline_policy in user["inline_policies"] : {
+        user_name   = user.name
+        policy_name = inline_policy["name"]
+        policy      = inline_policy
+      }
+    ]
+  ])
+  user_inline_policies = { for obj in local.uip : "${obj.user_name}:${obj.policy_name}" => obj.policy }
 }
 
 
 # -------------------------------------------------------------------------------------------------
-# Policy Arn transformations
+# Role/User Policy Arn transformations
 # -------------------------------------------------------------------------------------------------
 
 locals {
   # This local extracts policy_arns from var.roles and combines the found policies
   # with the role names as shown below:
   #
-  # policy_arns = [
+  # role_policy_arns = [
   #   {
   #     "<role-name>:<policy-arn>" = "<policy-arn>"
   #   },
@@ -145,7 +206,7 @@ locals {
   #     "<role-name>:<policy-arn>" = "<policy-arn>"
   #   },
   # ]
-  pa = flatten([
+  rpa = flatten([
     for role in var.roles : [
       for policy_arn in role["policy_arns"] : {
         role_name  = role.name
@@ -154,6 +215,27 @@ locals {
       }
     ]
   ])
+  role_policy_arns = { for obj in local.rpa : "${obj.role_name}:${obj.policy_arn}" => obj.policy }
 
-  policy_arns = { for obj in local.pa : "${obj.role_name}:${obj.policy_arn}" => obj.policy }
+  # This local extracts policy_arns from var.users and combines the found policies
+  # with the user names as shown below:
+  #
+  # user_policy_arns = [
+  #   {
+  #     "<user-name>:<policy-arn>" = "<policy-arn>"
+  #   },
+  #   {
+  #     "<user-name>:<policy-arn>" = "<policy-arn>"
+  #   },
+  # ]
+  upa = flatten([
+    for user in var.users : [
+      for policy_arn in user["policy_arns"] : {
+        user_name  = user.name
+        policy_arn = policy_arn
+        policy     = policy_arn
+      }
+    ]
+  ])
+  user_policy_arns = { for obj in local.upa : "${obj.user_name}:${obj.policy_arn}" => obj.policy }
 }

--- a/main.tf
+++ b/main.tf
@@ -126,7 +126,7 @@ resource "aws_iam_user_policy_attachment" "policy_attachments" {
   # must be run first in order to create the users,
   # so we must explicitly tell it.
   depends_on = [
-    aws_iam_role.users,
+    aws_iam_user.users,
     aws_iam_policy.policies,
   ]
 }

--- a/main.tf
+++ b/main.tf
@@ -119,7 +119,7 @@ resource "aws_iam_user" "users" {
 resource "aws_iam_access_key" "access_key" {
   for_each = local.user_access_keys
 
-  user    = each.key
+  user    = split(":", each.key)[0]
   pgp_key = each.value.pgp_key
   status  = each.value.status
 

--- a/main.tf
+++ b/main.tf
@@ -115,6 +115,19 @@ resource "aws_iam_user" "users" {
   )
 }
 
+# Add 'Active' or 'Inactive' access key to an IAM user
+resource "aws_iam_access_key" "access_key" {
+  for_each = local.user_access_keys
+
+  user    = each.key
+  pgp_key = each.value.pgp_key
+  status  = each.value.status
+
+  # Terraform has no info that aws_iam_users must be run first in order to create the users,
+  # so we must explicitly tell it.
+  depends_on = [aws_iam_user.users]
+}
+
 # Attach customer managed policies to user
 resource "aws_iam_user_policy_attachment" "policy_attachments" {
   for_each = local.user_policies

--- a/outputs-debug.tf
+++ b/outputs-debug.tf
@@ -67,6 +67,11 @@ output "debug_local_user_policies" {
   value       = local.user_policies
 }
 
+output "debug_local_user_access_keys" {
+  description = "The transformed user access key map"
+  value       = local.user_access_keys
+}
+
 output "debug_local_user_inline_policies" {
   description = "The transformed user inline policy map"
   value       = local.user_inline_policies

--- a/outputs-debug.tf
+++ b/outputs-debug.tf
@@ -1,0 +1,78 @@
+#
+# This file is for development only.
+# Comment out the outputs to see how how the transformations work.
+#
+
+# -------------------------------------------------------------------------------------------------
+# Input variables
+# -------------------------------------------------------------------------------------------------
+
+output "debug_var_roles" {
+  description = "The defined roles list"
+  value       = var.roles
+}
+
+output "debug_var_users" {
+  description = "The defined users list"
+  value       = var.users
+}
+
+output "debug_var_permissions_boundaries" {
+  description = "The defined roles list"
+  value       = var.permissions_boundaries
+}
+
+output "debug_var_policies" {
+  description = "The transformed policy map"
+  value       = var.policies
+}
+
+
+# -------------------------------------------------------------------------------------------------
+# Locals (policies)
+# -------------------------------------------------------------------------------------------------
+
+output "debug_local_policies" {
+  description = "The transformed policy map"
+  value       = local.policies
+}
+
+
+# -------------------------------------------------------------------------------------------------
+# Locals (roles)
+# -------------------------------------------------------------------------------------------------
+
+output "debug_local_role_policies" {
+  description = "The transformed role policy map"
+  value       = local.role_policies
+}
+
+output "debug_local_role_inline_policies" {
+  description = "The transformed role inline policy map"
+  value       = local.role_inline_policies
+}
+
+output "debug_local_role_policy_arns" {
+  description = "The transformed role policy arns map"
+  value       = local.role_policy_arns
+}
+
+
+# -------------------------------------------------------------------------------------------------
+# Locals (users)
+# -------------------------------------------------------------------------------------------------
+
+output "debug_local_user_policies" {
+  description = "The transformed user policy map"
+  value       = local.user_policies
+}
+
+output "debug_local_user_inline_policies" {
+  description = "The transformed user inline policy map"
+  value       = local.user_inline_policies
+}
+
+output "debug_local_user_policy_arns" {
+  description = "The transformed user policy arns map"
+  value       = local.user_policy_arns
+}

--- a/outputs.tf
+++ b/outputs.tf
@@ -1,111 +1,59 @@
 # -------------------------------------------------------------------------------------------------
-# Input variables
+# Policies
 # -------------------------------------------------------------------------------------------------
 
-output "var_roles" {
-  description = "The defined roles list"
-  value       = var.roles
-}
-
-output "var_users" {
-  description = "The defined users list"
-  value       = var.users
-}
-
-output "var_permissions_boundaries" {
-  description = "The defined roles list"
-  value       = var.permissions_boundaries
-}
-
-output "var_policies" {
-  description = "The transformed policy map"
-  value       = var.policies
-}
-
-# -------------------------------------------------------------------------------------------------
-# Transformed variables
-# -------------------------------------------------------------------------------------------------
-
-output "local_policies" {
-  description = "The transformed policy map"
-  value       = local.policies
-}
-
-output "local_role_policies" {
-  description = "The transformed role policy map"
-  value       = local.role_policies
-}
-
-output "local_role_inline_policies" {
-  description = "The transformed role inline policy map"
-  value       = local.role_inline_policies
-}
-
-output "local_role_policy_arns" {
-  description = "The transformed role policy arns map"
-  value       = local.role_policy_arns
-}
-
-output "local_user_policies" {
-  description = "The transformed user policy map"
-  value       = local.user_policies
-}
-
-output "local_user_inline_policies" {
-  description = "The transformed user inline policy map"
-  value       = local.user_inline_policies
-}
-
-output "local_user_policy_arns" {
-  description = "The transformed user policy arns map"
-  value       = local.user_policy_arns
-}
-
-# -------------------------------------------------------------------------------------------------
-# Created resources
-# -------------------------------------------------------------------------------------------------
-
-output "created_policies" {
+output "policies" {
   description = "Created customer managed IAM policies"
   value       = aws_iam_policy.policies
 }
 
-output "created_roles" {
+
+
+# -------------------------------------------------------------------------------------------------
+# Roles
+# -------------------------------------------------------------------------------------------------
+
+output "roles" {
   description = "Created IAM roles"
   value       = aws_iam_role.roles
 }
 
-output "created_role_policy_attachments" {
+output "role_policy_attachments" {
   description = "Attached role customer managed IAM policies"
   value       = aws_iam_role_policy_attachment.policy_attachments
 }
 
-output "created_role_inline_policy_attachments" {
+output "role_inline_policy_attachments" {
   description = "Attached role inline IAM policies"
   value       = aws_iam_role_policy.inline_policy_attachments
 }
 
-output "created_role_policy_arn_attachments" {
+output "role_policy_arn_attachments" {
   description = "Attached role IAM policy arns"
   value       = aws_iam_role_policy_attachment.policy_arn_attachments
 }
 
-output "created_users" {
+
+# -------------------------------------------------------------------------------------------------
+# Users
+# -------------------------------------------------------------------------------------------------
+
+output "users" {
   description = "Created IAM users"
   value       = aws_iam_user.users
 }
 
-output "created_user_policy_attachments" {
+output "user_policy_attachments" {
   description = "Attached user customer managed IAM policies"
   value       = aws_iam_user_policy_attachment.policy_attachments
 }
 
-output "created_user_inline_policy_attachments" {
+output "user_inline_policy_attachments" {
   description = "Attached user inline IAM policies"
   value       = aws_iam_user_policy.inline_policy_attachments
 }
 
-output "created_user_policy_arn_attachments" {
+output "user_policy_arn_attachments" {
   description = "Attached user IAM policy arns"
   value       = aws_iam_user_policy_attachment.policy_arn_attachments
 }

--- a/outputs.tf
+++ b/outputs.tf
@@ -7,6 +7,11 @@ output "var_roles" {
   value       = var.roles
 }
 
+output "var_users" {
+  description = "The defined users list"
+  value       = var.users
+}
+
 output "var_permissions_boundaries" {
   description = "The defined roles list"
   value       = var.permissions_boundaries
@@ -31,42 +36,76 @@ output "local_role_policies" {
   value       = local.role_policies
 }
 
-output "local_inline_policies" {
-  description = "The transformed inline policy map"
-  value       = local.inline_policies
+output "local_role_inline_policies" {
+  description = "The transformed role inline policy map"
+  value       = local.role_inline_policies
 }
 
-output "local_policy_arns" {
-  description = "The transformed policy arns map"
-  value       = local.policy_arns
+output "local_role_policy_arns" {
+  description = "The transformed role policy arns map"
+  value       = local.role_policy_arns
 }
 
+output "local_user_policies" {
+  description = "The transformed user policy map"
+  value       = local.user_policies
+}
+
+output "local_user_inline_policies" {
+  description = "The transformed user inline policy map"
+  value       = local.user_inline_policies
+}
+
+output "local_user_policy_arns" {
+  description = "The transformed user policy arns map"
+  value       = local.user_policy_arns
+}
 
 # -------------------------------------------------------------------------------------------------
 # Created resources
 # -------------------------------------------------------------------------------------------------
-
-output "created_roles" {
-  description = "Created IAM roles"
-  value       = aws_iam_role.roles
-}
 
 output "created_policies" {
   description = "Created customer managed IAM policies"
   value       = aws_iam_policy.policies
 }
 
-output "created_policy_attachments" {
-  description = "Attached customer managed IAM policies"
+output "created_roles" {
+  description = "Created IAM roles"
+  value       = aws_iam_role.roles
+}
+
+output "created_role_policy_attachments" {
+  description = "Attached role customer managed IAM policies"
   value       = aws_iam_role_policy_attachment.policy_attachments
 }
 
-output "created_inline_policy_attachments" {
-  description = "Attached inline IAM policies"
+output "created_role_inline_policy_attachments" {
+  description = "Attached role inline IAM policies"
   value       = aws_iam_role_policy.inline_policy_attachments
 }
 
-output "created_policy_arn_attachments" {
-  description = "Attached IAM policy arns"
+output "created_role_policy_arn_attachments" {
+  description = "Attached role IAM policy arns"
   value       = aws_iam_role_policy_attachment.policy_arn_attachments
+}
+
+output "created_users" {
+  description = "Created IAM users"
+  value       = aws_iam_user.users
+}
+
+output "created_user_policy_attachments" {
+  description = "Attached user customer managed IAM policies"
+  value       = aws_iam_user_policy_attachment.policy_attachments
+}
+
+output "created_user_inline_policy_attachments" {
+  description = "Attached user inline IAM policies"
+  value       = aws_iam_user_policy.inline_policy_attachments
+}
+
+output "created_user_policy_arn_attachments" {
+  description = "Attached user IAM policy arns"
+  value       = aws_iam_user_policy_attachment.policy_arn_attachments
 }

--- a/variables.tf
+++ b/variables.tf
@@ -112,17 +112,27 @@ variable "permissions_boundaries" {
 #
 # users = [
 #   {
-#     name              = "ADMIN-USER"
-#     path              = ""
-#     policies          = []
-#     inline_policies   = []
+#     name       = "ADMIN-USER"
+#     path       = ""
+#     access_key = {
+#       create  = false
+#       pgp_key = ""
+#       status  = ""
+#     }
+#     policies        = []
+#     inline_policies = []
 #     policy_arns = [
 #       "arn:aws:iam::aws:policy/AdministratorAccess",
 #     ]
 #   },
 #   {
-#     name              = "POWER-USER"
-#     path              = ""
+#     name       = "POWER-USER"
+#     path       = ""
+#     access_key = {
+#       create  = true
+#       pgp_key = ""
+#       status  = "Active"
+#     }
 #     policies = [
 #       "assume-human-ro-billing",
 #     ]
@@ -135,8 +145,13 @@ variable "permissions_boundaries" {
 variable "users" {
   description = "A list of dictionaries defining all users."
   type = list(object({
-    name     = string       # Name of the user
-    path     = string       # Defaults to 'var.user_path' variable is set to null
+    name       = string  # Name of the user
+    path       = string  # Defaults to 'var.user_path' variable is set to null
+    access_key = object({
+      create  = bool     # Create Access key and secret?
+      pgp_key = string   # Leave empty for non or provide a b64-enc pubkey or keybase username
+      status  = string   # 'Active' or 'Inactive'
+    })
     policies = list(string) # List of names of policies (must be defined in var.policies)
     inline_policies = list(object({
       name = string      # Name of the inline policy

--- a/variables.tf
+++ b/variables.tf
@@ -114,11 +114,18 @@ variable "permissions_boundaries" {
 #   {
 #     name       = "ADMIN-USER"
 #     path       = ""
-#     access_key = {
-#       create  = false
-#       pgp_key = ""
-#       status  = ""
-#     }
+#     access_keys = [
+#       {
+#         name    = "key1"
+#         pgp_key = ""
+#         status  = ""
+#       },
+#       {
+#         name    = "key2"
+#         pgp_key = ""
+#         status  = ""
+#       }
+#     ]
 #     policies        = []
 #     inline_policies = []
 #     policy_arns = [
@@ -128,11 +135,7 @@ variable "permissions_boundaries" {
 #   {
 #     name       = "POWER-USER"
 #     path       = ""
-#     access_key = {
-#       create  = true
-#       pgp_key = ""
-#       status  = "Active"
-#     }
+#     access_keys = []
 #     policies = [
 #       "assume-human-ro-billing",
 #     ]
@@ -147,11 +150,11 @@ variable "users" {
   type = list(object({
     name = string # Name of the user
     path = string # Defaults to 'var.user_path' variable is set to null
-    access_key = object({
-      create  = bool   # Create Access key and secret?
+    access_keys = list(object({
+      name    = string # IaC identifier for first or second IAM access key (not used on AWS)
       pgp_key = string # Leave empty for non or provide a b64-enc pubkey or keybase username
       status  = string # 'Active' or 'Inactive'
-    })
+    }))
     policies = list(string) # List of names of policies (must be defined in var.policies)
     inline_policies = list(object({
       name = string      # Name of the inline policy

--- a/variables.tf
+++ b/variables.tf
@@ -145,12 +145,12 @@ variable "permissions_boundaries" {
 variable "users" {
   description = "A list of dictionaries defining all users."
   type = list(object({
-    name       = string  # Name of the user
-    path       = string  # Defaults to 'var.user_path' variable is set to null
+    name = string # Name of the user
+    path = string # Defaults to 'var.user_path' variable is set to null
     access_key = object({
-      create  = bool     # Create Access key and secret?
-      pgp_key = string   # Leave empty for non or provide a b64-enc pubkey or keybase username
-      status  = string   # 'Active' or 'Inactive'
+      create  = bool   # Create Access key and secret?
+      pgp_key = string # Leave empty for non or provide a b64-enc pubkey or keybase username
+      status  = string # 'Active' or 'Inactive'
     })
     policies = list(string) # List of names of policies (must be defined in var.policies)
     inline_policies = list(object({

--- a/variables.tf
+++ b/variables.tf
@@ -21,10 +21,16 @@
 #     file = "policies/human/ro-billing.json"
 #     vars = {}
 #   },
+#   {
+#     name = "sqs-ro"
+#     path = "/custom/human/"
+#     desc = "Provides read-only access to SQS"
+#     file = "policies/human/sqs-ro.json"
+#     vars = {}
+#   },
 # ]
-
 variable "policies" {
-  description = "A list of dictionaries defining all roles."
+  description = "A list of dictionaries defining all policies."
   type = list(object({
     name = string      # Name of the policy
     path = string      # Defaults to 'var.policy_path' variable is set to null
@@ -68,7 +74,6 @@ variable "policies" {
 #     ]
 #   },
 # ]
-
 variable "roles" {
   description = "A list of dictionaries defining all roles."
   type = list(object({
@@ -92,11 +97,54 @@ variable "roles" {
 # permissions_boundaries = {
 #   <role-name> = "arn:aws:iam::1234567890:policy/test-perm-boundaries/test-default"
 # }
-
 variable "permissions_boundaries" {
   description = "A map of strings containing ARN's of policies to attach as permissions boundaries to roles."
   type        = map(string)
   default     = {}
+}
+
+
+# -------------------------------------------------------------------------------------------------
+# User definition
+# -------------------------------------------------------------------------------------------------
+
+# Example user definition:
+#
+# users = [
+#   {
+#     name              = "ADMIN-USER"
+#     path              = ""
+#     policies          = []
+#     inline_policies   = []
+#     policy_arns = [
+#       "arn:aws:iam::aws:policy/AdministratorAccess",
+#     ]
+#   },
+#   {
+#     name              = "POWER-USER"
+#     path              = ""
+#     policies = [
+#       "assume-human-ro-billing",
+#     ]
+#     inline_policies = []
+#     policy_arns = [
+#       "arn:aws:iam::aws:policy/PowerUserAccess",
+#     ]
+#   },
+# ]
+variable "users" {
+  description = "A list of dictionaries defining all users."
+  type = list(object({
+    name     = string       # Name of the user
+    path     = string       # Defaults to 'var.user_path' variable is set to null
+    policies = list(string) # List of names of policies (must be defined in var.policies)
+    inline_policies = list(object({
+      name = string      # Name of the inline policy
+      file = string      # Path to json or json.tmpl file of policy
+      vars = map(string) # Policy template variables {key = val, ...}
+    }))
+    policy_arns = list(string) # List of existing policy ARN's
+  }))
 }
 
 
@@ -129,18 +177,33 @@ variable "role_desc" {
   default     = "Managed by Terraform"
 }
 
-variable "max_session_duration" {
+variable "role_max_session_duration" {
   description = "The maximum session duration (in seconds) that you want to set for the specified role. This setting can have a value from 1 hour to 12 hours specified in seconds."
   default     = "3600"
 }
 
-variable "force_detach_policies" {
+variable "role_force_detach_policies" {
   description = "Specifies to force detaching any policies the role has before destroying it."
   default     = true
 }
 
+
+# -------------------------------------------------------------------------------------------------
+# Default User settings
+# -------------------------------------------------------------------------------------------------
+
+variable "user_path" {
+  description = "The path under which to create the user. You can use a single path, or nest multiple paths as if they were a folder structure. For example, you could use the nested path /division_abc/subdivision_xyz/product_1234/engineering/ to match your company's organizational structure."
+  default     = "/"
+}
+
+
+# -------------------------------------------------------------------------------------------------
+# Default general settings
+# -------------------------------------------------------------------------------------------------
+
 variable "tags" {
-  description = "Key-value mapping of tags for the IAM role."
-  type        = map
+  description = "Key-value mapping of tags for the IAM role or user."
+  type        = map(any)
   default     = {}
 }


### PR DESCRIPTION
# Add user management

* Be able to manage users as is currently done with roles
* Allow to rotate IAM user access/secret keys via IaC
* Separate normal outputs from debug outputs

## Things to discuss (update) :heavy_check_mark:  (this is implemented now)

It seems that you can actually create up to two access keys for an IAM user.
Adding this feature as well, will require rewriting the `access_key` section of the user and make it a list instead. This would probably also allow for an easier definition if no access key is required (then you can just make it an empty list without having to specify each object key and would also allow to omit the `create` sub key).

Having two access keys is a method of rotating them: https://docs.aws.amazon.com/IAM/latest/UserGuide/id_credentials_access-keys.html#rotating_access_keys_console

Please let me know your thoughts here.


## Important note :exclamation: 

When creating an IAM user with an `Inactive` access key it is initially create with access key set to `Active`. You will have to run it a second time in order to deactivate the access key.
This is either an issue with the terraform resource `aws_iam_access_key` or with the AWS api itself.

## Example (new: with IAM user key rotation)
```hcl
users = [
  {
    name            = "admin"
    path            = null
    access_keys     = []
    policies        = []
    inline_policies = []
    policy_arns = [
      "arn:aws:iam::aws:policy/AdministratorAccess",
    ]
  },
  {
    name        = "developer"
    path        = null
    access_keys = [
      {
        name    = "key-1"
        pgp_key = ""
        status  = "Active"
      }
    ]
    policies    = [
      "rds-authenticate",
    ]
    inline_policies = []
    policy_arns     = []
  },
]

```

## Example (old see https://github.com/Flaconi/terraform-aws-iam-roles/pull/5/commits/dce178961129924ae60fa769af4d7abdecc6f9db for changes)
```hcl
users = [
  {
    name       = "cytopia-test"
    path       = null
    access_key = {
      create  = true
      pgp_key = ""
      status  = "Inactive"
    }
    policies = [
      "rds-authenticate",
    ]
    inline_policies = []
    policy_arns = [
      "arn:aws:iam::aws:policy/AdministratorAccess",
    ]
  },
  {
    name       = "cytopia-test-2"
    path       = null
    access_key = {
      create  = true
      pgp_key = ""
      status  = "Active"
    }
    policies = [
      "rds-authenticate",
    ]
    inline_policies = []
    policy_arns = [
      "arn:aws:iam::aws:policy/AdministratorAccess",
    ]
  },
]
```


## Release notes

This will be released as a major version as there are some changes in variable names which won't be backwards compatible to old setups without changing the input variables


## Future plans :exclamation: 

Once IAM groups are implemented, this module will cover almost anything in AWS IAM and will be renamed to `terraform-aws-iam`.