### PR TITLE
Ops 5891 dynamic boundary fix

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,8 +5,9 @@
 *.tfstate
 *.tfstate.*
 
-# .tfvars files
+# exclude .tfvars except for examples
 *.tfvars
+!examples/*/*.tfvars
 
 # lock file
 .terraform.lock.hcl

--- a/examples/roles-with-dynamic-permission-boundary/terraform.tfvars
+++ b/examples/roles-with-dynamic-permission-boundary/terraform.tfvars
@@ -1,0 +1,51 @@
+# set path for permission boundary
+role_perm_bound_policy_path = "/perm-boundaries/"
+
+roles = [
+  {
+    name              = "ROLE-DYNAMIC-BOUNDARIES-EXAMPLE-1"
+    trust_policy_file = "data/trust-policy-file.json"
+    trust_policy_vars = {
+      ACCOUNT_ID = "608780100653",
+      ROLE_NAME  = "LOGIN-TEST-DYNAMIC-BOUNDARIES-1"
+    }
+    policies        = []
+    inline_policies = []
+    policy_arns     = []
+    permission_boundary_policies = [
+      {
+        file = "data/boundary-example1.json.tftpl"
+        vars = {
+          aws_account_id = "1234567890"
+        }
+      },
+      {
+        file = "data/boundary-example2.json.tftpl"
+      }
+    ]
+  },
+  {
+    name              = "ROLE-DYNAMIC-BOUNDARIES-EXAMPLE-2"
+    trust_policy_file = "data/trust-policy-file.json"
+    trust_policy_vars = {
+      ACCOUNT_ID = "608780100653",
+      ROLE_NAME  = "LOGIN-TEST-DYNAMIC-BOUNDARIES-2"
+    }
+    policies    = []
+    policy_arns = []
+    permission_boundary_policies = [
+      {
+        file = "data/boundary-example1.json.tftpl"
+        vars = {
+          aws_account_id = "1234567890",
+        }
+      }
+    ]
+  },
+  {
+    name                 = "ROLE-PERMISSION-BOUNDARY-WITHOUT-POLICIES"
+    trust_policy_file    = "data/trust-policy-file.json"
+    permissions_boundary = "arn:aws:iam::aws:policy/PowerUserAccess"
+    policy_arns          = ["arn:aws:iam::aws:policy/AdministratorAccess"]
+  },
+]

--- a/variables.tf
+++ b/variables.tf
@@ -262,6 +262,12 @@ variable "roles" {
     })), [])
   }))
   default = []
+  validation {
+    condition = length(var.roles) > 0 ? alltrue([
+      for role in var.roles : !(role.permissions_boundary != null && length(role.permission_boundary_policies) > 0)
+    ]) : true
+    error_message = "Either permission_boundary or permission_boundary_policies value should be set, but not both."
+  }
 }
 
 


### PR DESCRIPTION
- .gitignore to exclude .tfvars except for examples
- added missing tfvars for dynamic permission boundary example